### PR TITLE
New features

### DIFF
--- a/data/css/main.css
+++ b/data/css/main.css
@@ -1,5 +1,5 @@
 body {
-  width: 10px;
+  width: auto;
 }
 
 div {

--- a/data/data-providers.json
+++ b/data/data-providers.json
@@ -59,9 +59,8 @@
   "KrakenRipple": { "exchangeName":"Kraken", "currency":"\u0243",  "baseCurrency":"XRP", "url":"https://api.kraken.com/0/public/Ticker?pair=XBTXRP", "jsonPath":["result","XXBTXXRP","c",0]},
   "KrakenEther": { "exchangeName":"Kraken", "currency":"\u0243",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHXXBT", "jsonPath":["result","XETHXXBT","c",0]},
   "KrakenEtherEUR": { "exchangeName":"Kraken", "currency":"\u20ac",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHZEUR", "jsonPath":["result","XETHZEUR","c",0]},
-  "KrakenEtherUSD": { "exchangeName":"Kraken", "currency":"$",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHZUSD", "jsonPath":["result","XETHZUSD","c",0]}
+  "KrakenEtherUSD": { "exchangeName":"Kraken", "currency":"$",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHZUSD", "jsonPath":["result","XETHZUSD","c",0]},
 
-  "Poloniex": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_", "last"]},
   "PoloniexBelaCoin": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BELA", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BELA", "last"]},
   "PoloniexBitshares": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTS", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTS", "last"]},
   "PoloniexBitcoindark": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTCD", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTCD", "last"]},
@@ -75,10 +74,9 @@
   "PoloniexNxt": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"NXT", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_NXT", "last"]},
   "PoloniexPascal": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"PASC", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_PASC", "last"]},
   "PoloniexNem": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XEM", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XEM", "last"]},
-  "PoloniexMonero": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XMR", "last"]},  
   "PoloniexRipple": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XRP", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XRP", "last"]},
     
   "PoloniexMoneroUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_XMR", "last"]},
-  "PoloniexDashUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_DASH", "last"]},
+  "PoloniexDashUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_DASH", "last"]}
 
 }

--- a/data/data-providers.json
+++ b/data/data-providers.json
@@ -23,17 +23,11 @@
   "BitPayGBP": { "exchangeName":"BitPay", "currency":"\u00a3",  "baseCurrency":"\u0243", "url":"https://bitpay.com/api/rates", "jsonPath":[3,"rate"]},
 
   "BitcurexPLN": { "exchangeName":"Bitcurex", "currency":"z\u0141",  "baseCurrency":"\u0243", "url":"https://bitcurex.com/api/pln/ticker.json", "jsonPath":["last_tx_price"]},
-
   "CaVirTexCAD": { "exchangeName":"CaVirTex", "currency":"C$",  "baseCurrency":"\u0243", "url":"https://www.cavirtex.com/api/CAD/ticker.json", "jsonPath":["last"]},
-
   "BTCChinaCNY": { "exchangeName":"BTCChina", "currency":"\u00a5",  "baseCurrency":"\u0243", "url":"https://data.btcchina.com/data/ticker", "jsonPath":["ticker","last"]},
-
   "BTCeRUR": { "exchangeName":"BTCe", "currency":"RUR",  "baseCurrency":"\u0243", "url":"https://btc-e.com/api/2/btc_rur/ticker", "jsonPath":["ticker","last"]},
-
   "MercadoBitcoinBRL": { "exchangeName":"MercadoBitcoin", "currency":"R$",  "baseCurrency":"\u0243", "url":"https://www.mercadobitcoin.com.br/api/ticker/", "jsonPath":["ticker","last"]},
-
   "BTCTurkTRY": { "exchangeName":"BTCTurk", "currency":"\u20ba",  "baseCurrency":"\u0243", "url":"https://www.btcturk.com/api/ticker", "jsonPath":["last"]},
-
   "BitcoinVenezuelaVEF": { "exchangeName":"BitcoinVenezuela", "currency":"Bs",  "baseCurrency":"\u0243", "url":"http://bitcoinvenezuela.com/api/btcven.json", "jsonPath":["BTC","VEF"]},
   "LocalbitcoinsVEF": { "exchangeName":"Localbitcoins", "currency":"Bs",  "baseCurrency":"\u0243", "url":"https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/", "jsonPath":["VEF","rates","last"]},
   "CoinbaseVEF": { "exchangeName":"Coinbase", "currency":"Bs",  "baseCurrency":"\u0243", "url":"https://coinbase.com/api/v1/currencies/exchange_rates", "jsonPath":["btc_to_vef"]},
@@ -61,27 +55,30 @@
   "KrakenDogecoin": { "exchangeName":"Kraken", "currency":"DOGE",  "baseCurrency":"\u0243", "url":"https://api.kraken.com/0/public/Ticker?pair=XBTXDG", "jsonPath":["result","XXBTXXDG","c",0]},
 
   "BTCeNamecoinUSD": { "exchangeName":"BTCe", "currency":"$",  "baseCurrency":"NMC", "url":"https://btc-e.com/api/2/nmc_usd/ticker", "jsonPath":["ticker","last"]},
-  "PoloniexNxt": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"NXT", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_NXT", "last"]},
-
-  "PoloniexBitshares": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTS", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTS", "last"]},
 
   "KrakenRipple": { "exchangeName":"Kraken", "currency":"\u0243",  "baseCurrency":"XRP", "url":"https://api.kraken.com/0/public/Ticker?pair=XBTXRP", "jsonPath":["result","XXBTXXRP","c",0]},
-
-  "PoloniexMaidsafe": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"MAID", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_MAID", "last"]},
-
-  "PoloniexBitcoindark": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTCD", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTCD", "last"]},
-
-  "PoloniexMonero": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XMR", "last"]},
-  "PoloniexMoneroUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_XMR", "last"]},
-
-  "PoloniexDash": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_DASH", "last"]},
-  "PoloniexDashUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_DASH", "last"]},
-
-  "PoloniexBurst": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BURST", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BURST", "last"]},
-
   "KrakenEther": { "exchangeName":"Kraken", "currency":"\u0243",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHXXBT", "jsonPath":["result","XETHXXBT","c",0]},
-  "PoloniexEther": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"ETH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_ETH", "last"]},
-  "PoloniexEtherClassic": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"ETC", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_ETC", "last"]},
   "KrakenEtherEUR": { "exchangeName":"Kraken", "currency":"\u20ac",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHZEUR", "jsonPath":["result","XETHZEUR","c",0]},
   "KrakenEtherUSD": { "exchangeName":"Kraken", "currency":"$",  "baseCurrency":"ETH", "url":"https://api.kraken.com/0/public/Ticker?pair=XETHZUSD", "jsonPath":["result","XETHZUSD","c",0]}
+
+  "Poloniex": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_", "last"]},
+  "PoloniexBelaCoin": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BELA", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BELA", "last"]},
+  "PoloniexBitshares": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTS", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTS", "last"]},
+  "PoloniexBitcoindark": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTCD", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTCD", "last"]},
+  "PoloniexBurst": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BURST", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BURST", "last"]},
+  "PoloniexDash": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_DASH", "last"]},
+  "PoloniexEther": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"ETH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_ETH", "last"]},
+  "PoloniexEtherClassic": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"ETC", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_ETC", "last"]},
+  "PoloniexLiteCoin": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"LTC", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_LTC", "last"]},
+  "PoloniexMaidsafe": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"MAID", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_MAID", "last"]},
+  "PoloniexMonero": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XMR", "last"]},
+  "PoloniexNxt": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"NXT", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_NXT", "last"]},
+  "PoloniexPascal": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"PASC", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_PASC", "last"]},
+  "PoloniexNem": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XEM", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XEM", "last"]},
+  "PoloniexMonero": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XMR", "last"]},  
+  "PoloniexRipple": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XRP", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XRP", "last"]},
+    
+  "PoloniexMoneroUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_XMR", "last"]},
+  "PoloniexDashUSD": { "exchangeName":"Poloniex", "currency":"$",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["USDT_DASH", "last"]},
+
 }

--- a/data/js/controllers.js
+++ b/data/js/controllers.js
@@ -68,7 +68,7 @@ function updateTicker(tickerModel) {
     if (tickerView) {
       updateView(tickerId, tickerModel.price, tickerModel.exchangeName, tickerModel.currency, 
                   tickerModel.baseCurrency, tickerModel.currencyPosition, tickerModel.color,
-                  tickerModel.fontSize, tickerModel.background, tickerModel.currencyName, tickerModel.noRounding);
+                  tickerModel.fontSize, tickerModel.background, tickerModel.showCurrencyName, tickerModel.noRounding);
     }
   } else {
     if (tickerView) {

--- a/data/js/controllers.js
+++ b/data/js/controllers.js
@@ -68,7 +68,7 @@ function updateTicker(tickerModel) {
     if (tickerView) {
       updateView(tickerId, tickerModel.price, tickerModel.exchangeName, tickerModel.currency, 
                   tickerModel.baseCurrency, tickerModel.currencyPosition, tickerModel.color,
-                  tickerModel.fontSize, tickerModel.background);
+                  tickerModel.fontSize, tickerModel.background, tickerModel.currencyName, tickerModel.noRounding);
     }
   } else {
     if (tickerView) {

--- a/data/js/models.js
+++ b/data/js/models.js
@@ -67,6 +67,8 @@ function createTickerModel(id) {
     fontSize: null,
     background: null,
     price: 0,
+    currencyName: false,
+    noRounding: false,
     observers: [],
     // Retrieve tickers provider and configuration data from repository
     initialize: function(observer) {

--- a/data/js/models.js
+++ b/data/js/models.js
@@ -104,7 +104,18 @@ function updateTickerModelConfiguration(tickerModel, data) {
       tickerModel.enabled = data.enabled ? true : false;
     }
   }
-
+  if (data.currencyName) {
+  	if (data.currencyName != tickerModel.currencyName) {
+  		notifyObservers = true;
+  	}
+  	tickerModel.currencyName = data.currencyName;
+  }
+  if (data.noRounding) {
+  	if (data.noRounding != tickerModel.noRounding) {
+  		notifyObservers = true;
+  	}
+  	tickerModel.noRounding = data.noRounding;
+  }
   if (data.currencyPosition) {
     if (data.currencyPosition != tickerModel.currencyPosition) {
       notifyObservers = true;

--- a/data/js/models.js
+++ b/data/js/models.js
@@ -67,7 +67,7 @@ function createTickerModel(id) {
     fontSize: null,
     background: null,
     price: 0,
-    currencyName: false,
+    showCurrencyName: false,
     noRounding: false,
     observers: [],
     // Retrieve tickers provider and configuration data from repository
@@ -104,11 +104,11 @@ function updateTickerModelConfiguration(tickerModel, data) {
       tickerModel.enabled = data.enabled ? true : false;
     }
   }
-  if (data.currencyName) {
-  	if (data.currencyName != tickerModel.currencyName) {
+  if (data.showCurrencyName) {
+  	if (data.showCurrencyName != tickerModel.showCurrencyName) {
   		notifyObservers = true;
   	}
-  	tickerModel.currencyName = data.currencyName;
+  	tickerModel.showCurrencyName = data.showCurrencyName;
   }
   if (data.noRounding) {
   	if (data.noRounding != tickerModel.noRounding) {

--- a/data/js/views.js
+++ b/data/js/views.js
@@ -76,10 +76,9 @@ function updateView(tickerId, price, exchangeName, currency, baseCurrency, curre
   tickerView.attr("title", label);
 }
 
-function formatTickerText(price, currency, currencyPosition, currencyName, noRounding, baseCurrency) { // Allow more decimals for low price values
+function formatTickerText(price, currency, currencyPosition, showCurrencyName, noRounding, baseCurrency) { // Allow more decimals for low price values
   if (price == parseFloat(price)) {
-  	if (!noRounding) { var tickerText = calculateRoundedPrice(price); }
-  	else { var tickerText = price; }
+  	var tickerText = noRounding ? price : calculateRoundedPrice(price);
     
     switch (currencyPosition) {
       case 'B':
@@ -89,7 +88,7 @@ function formatTickerText(price, currency, currencyPosition, currencyName, noRou
         tickerText =  tickerText + currency;
         break;
     }
-    if (currencyName) { tickerText = baseCurrency + " " + tickerText; }
+    if (showCurrencyName) { tickerText = baseCurrency + " " + tickerText; }
     return tickerText;
   } else {
     return price; // Text can not be formatted into a number

--- a/data/js/views.js
+++ b/data/js/views.js
@@ -61,7 +61,7 @@ function updateStyle(tickerId, color, fontSize, background) {
   }
 }
 
-function updateView(tickerId, price, exchangeName, currency, baseCurrency, currencyPosition, color, fontSize, background) {
+function updateView(tickerId, price, exchangeName, currency, baseCurrency, currencyPosition, color, fontSize, background, currencyName, noRounding) {
   if (price == 0) {
     return; // Avoid empty updates of view
   }
@@ -70,16 +70,17 @@ function updateView(tickerId, price, exchangeName, currency, baseCurrency, curre
     return; // Ticker was removed
   }
   updateStyle(tickerId, color, fontSize, background);
-  tickerView.text(formatTickerText(price, currency, currencyPosition));
+  tickerView.text(formatTickerText(price, currency, currencyPosition, currencyName, noRounding, baseCurrency));
   var label = exchangeName + " " + currency + "/" + baseCurrency;
   tickerView.attr("tooltiptext", label);
   tickerView.attr("title", label);
 }
 
-function formatTickerText(price, currency, currencyPosition) { // Allow more decimals for low price values
+function formatTickerText(price, currency, currencyPosition, currencyName, noRounding, baseCurrency) { // Allow more decimals for low price values
   if (price == parseFloat(price)) {
-    var roundedPrice = calculateRoundedPrice(price);
-    var tickerText = roundedPrice;
+  	if (!noRounding) { var tickerText = calculateRoundedPrice(price); }
+  	else { var tickerText = price; }
+    
     switch (currencyPosition) {
       case 'B':
         tickerText = currency + roundedPrice;
@@ -88,6 +89,7 @@ function formatTickerText(price, currency, currencyPosition) { // Allow more dec
         tickerText =  roundedPrice + currency;
         break;
     }
+    if (currencyName) { tickerText = baseCurrency + " " + tickerText; }
     return tickerText;
   } else {
     return price; // Text can not be formatted into a number

--- a/data/js/views.js
+++ b/data/js/views.js
@@ -83,10 +83,10 @@ function formatTickerText(price, currency, currencyPosition, currencyName, noRou
     
     switch (currencyPosition) {
       case 'B':
-        tickerText = currency + roundedPrice;
+        tickerText = currency + tickerText;
         break;
       case 'A':
-        tickerText =  roundedPrice + currency;
+        tickerText =  tickerText + currency;
         break;
     }
     if (currencyName) { tickerText = baseCurrency + " " + tickerText; }

--- a/index.js
+++ b/index.js
@@ -145,7 +145,8 @@ Preferences.on("other-background", updateActiveTickersSharedStyle);
 // Preferences.on("show-long-trend", updateAllTickers);
 // Preferences.on("show-short-trend", updateAllTickers);
 Preferences.on("show-currency-label", updateActiveTickersSharedStyle);
-
+Preferences.on("show-currency-name", updateActiveTickersSharedStyle);
+Preferences.on("do-not-round", updateActiveTickersSharedStyle);
 Preferences.on("infoButton", showAddonUpdateDocument);
 // Check updated version
 AddonManager.getAddonByID(ADDON_ID, function(addon) {
@@ -182,6 +183,8 @@ function getTickerConfigurationData(tickerId) {
     ticker.color = getStringPreference("p" + tickerId + "Color");
     ticker.fontSize = fontSize;
     ticker.background = getBackgroundColor(tickerId);
+    ticker.currencyName = getBooleanPreference("show-currency-name");
+    ticker.noRounding = getBooleanPreference("do-not-round");
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ function getTickerConfigurationData(tickerId) {
     ticker.color = getStringPreference("p" + tickerId + "Color");
     ticker.fontSize = fontSize;
     ticker.background = getBackgroundColor(tickerId);
-    ticker.currencyName = getBooleanPreference("show-currency-name");
+    ticker.showCurrencyName = getBooleanPreference("show-currency-name");
     ticker.noRounding = getBooleanPreference("do-not-round");
   }
 }

--- a/package.json
+++ b/package.json
@@ -631,10 +631,15 @@
     "description": "Currencies from Poloniex Exchange",
     "type": "bool",
     "value": false
+  },{
+    "name": "pPoloniexBelaCoinColor",
+    "title": "Poloniex Bitcoin/Belacoin Ticker color",
+    "type": "color",
+    "value": "#000"
   },
   {
     "name": "pPoloniexBitshares",
-    "title": "Poloniex Bitcoin/ (\u0243/BTS) ticker?",
+    "title": "Poloniex Bitcoin/Bitshares (\u0243/BTS) ticker?",
     "type": "bool",
     "value": false
   },{
@@ -663,7 +668,7 @@
     "name": "pPoloniexBurstColor",
     "title": "Poloniex Bitcoin/Burst Ticker color",
     "type": "color",
-    "value": "#FFF"
+    "value": "#000"
   },
   {
     "name": "pPoloniexDash",
@@ -685,7 +690,7 @@
     "name": "pPoloniexEtherColor",
     "title": "Poloniex Bitcoin/Ether Ticker color",
     "type": "color",
-    "value": "#FFF"
+    "value": "#000"
   },
   {
     "name": "pPoloniexEtherClassic",
@@ -696,13 +701,18 @@
     "name": "pPoloniexEtherClassicColor",
     "title": "Poloniex Bitcoin/Ethereum Classic Ticker color",
     "type": "color",
-    "value": "#FFF"
+    "value": "#000"
   },
   {
     "name": "pPoloniexLiteCoin",
     "title": "Poloniex Bitcoin/Litecoin (\u0243/LTC) ticker?",
     "type": "bool",
     "value": false
+  },{
+    "name": "pPoloniexLiteCoinColor",
+    "title": "Poloniex Bitcoin/Litecoin Ticker color",
+    "type": "color",
+    "value": "#000"
   },
   {
     "name": "pPoloniexMaidsafe",
@@ -742,18 +752,33 @@
     "title": "Poloniex Bitcoin/Pascal (\u0243/PASC) ticker?",
     "type": "bool",
     "value": false
+  },{
+    "name": "pPoloniexPascalColor",
+    "title": "Poloniex Bitcoin/Pascal Ticker color",
+    "type": "color",
+    "value": "#000"
   },
   {
     "name": "pPoloniexNem",
     "title": "Poloniex Bitcoin/NEM coin (\u0243/XEM) ticker?",
     "type": "bool",
     "value": false
+  },{
+    "name": "pPoloniexNemColor",
+    "title": "Poloniex Bitcoin/NEM coin Ticker color",
+    "type": "color",
+    "value": "#000"
   },
   {
     "name": "pPoloniexRipple",
     "title": "Poloniex Bitcoin/Ripple (\u0243/XRP) ticker?",
     "type": "bool",
     "value": false
+  },{
+    "name": "pPoloniexRippleColor",
+    "title": "Poloniex Bitcoin/Ripple Ticker color",
+    "type": "color",
+    "value": "#000"
   },
   {
     "name": "pPoloniexMoneroUSD",

--- a/package.json
+++ b/package.json
@@ -80,18 +80,17 @@
       }]
   },
   {
-  	"name": "show-currency-name",
-  	"title": "Display currency initials in front of ticker?"
-  	"type": "bool",
-  	"value": false
+    "name": "show-currency-name",
+    "title": "Display currency initials in front of ticker?",
+    "type": "bool",
+    "value": false
   },
   {
-  	"name": "do-not-round",
-  	"title": "Do not make rounding for currency value"
-  	"type": "bool",
-  	"value": false
+    "name": "do-not-round",
+    "title": "Do not make rounding for currency value",
+    "type": "bool",
+    "value": false
   },
-  
   {
     "name": "show-updates",
     "title": "Show new features page when there is an update",
@@ -583,28 +582,6 @@
     "value": "#1E2654"
   },
   {
-    "name": "pPoloniexNxt",
-    "title": "Poloniex Bitcoin/Nxt (\u0243/NXT) ticker?",
-    "type": "bool",
-    "value": true
-  },{
-    "name": "pPoloniexNxtColor",
-    "title": "Poloniex Bitcoin/Nxt Ticker color",
-    "type": "color",
-    "value": "#413ADF"
-  },
-  {
-    "name": "pPoloniexBitshares",
-    "title": "Poloniex Bitcoin/Bitshares (\u0243/BTS) ticker?",
-    "type": "bool",
-    "value": true
-  },{
-    "name": "pPoloniexBitsharesColor",
-    "title": "Poloniex Bitcoin/Bitshares Ticker color",
-    "type": "color",
-    "value": "#131F37"
-  },
-  {
     "name": "pKrakenRipple",
     "title": "Kraken Ripple/Bitcoin (XRP/\u0243) ticker? (inverted price)",
     "type": "bool",
@@ -616,83 +593,6 @@
     "value": "#131F37"
   },
   {
-    "name": "pPoloniexMaidsafe",
-    "title": "Poloniex Bitcoin/Maidsafe (\u0243/MAID) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexMaidsafeColor",
-    "title": "Poloniex Bitcoin/Maidsafe Ticker color",
-    "type": "color",
-    "value": "#000000"
-  },
-  {
-    "name": "pPoloniexBitcoindark",
-    "title": "Poloniex Bitcoin/BitcoinDark (\u0243/BTCD) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexBitcoindarkColor",
-    "title": "Poloniex Bitcoin/BitcoinDark Ticker color",
-    "type": "color",
-    "value": "#000000"
-  },
-  {
-    "name": "pPoloniexMonero",
-    "title": "Poloniex Bitcoin/Monero (\u0243/XMR) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexMoneroColor",
-    "title": "Poloniex Bitcoin/Monero Ticker color",
-    "type": "color",
-    "value": "#413ADF"
-  },
-  {
-    "name": "pPoloniexMoneroUSD",
-    "title": "Poloniex USD/Monero ($/XMR) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexMoneroUSDColor",
-    "title": "Poloniex USD/Monero Ticker color",
-    "type": "color",
-    "value": "#413ADF"
-  },
-  {
-    "name": "pPoloniexDash",
-    "title": "Poloniex Bitcoin/Dash (\u0243/DASH) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexDashColor",
-    "title": "Poloniex Bitcoin/Dash Ticker color",
-    "type": "color",
-    "value": "#1c75bc"
-  },
-  {
-    "name": "pPoloniexDashUSD",
-    "title": "Poloniex $/Dash ($/DASH) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexDashUSDColor",
-    "title": "Poloniex $/Dash Ticker color",
-    "type": "color",
-    "value": "#1c75bc"
-  },
-  {
-    "name": "pPoloniexBurst",
-    "title": "Poloniex Bitcoin/Burst (\u0243/BURST) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexBurstColor",
-    "title": "Poloniex Bitcoin/Burst Ticker color",
-    "type": "color",
-    "value": "#FFF"
-  },
-  {
     "name": "pKrakenEther",
     "title": "Kraken Bitcoin/Ether (\u0243/Ether) ticker?",
     "type": "bool",
@@ -700,28 +600,6 @@
   },{
     "name": "pKrakenEtherColor",
     "title": "Kraken Bitcoin/Ether Ticker color",
-    "type": "color",
-    "value": "#FFF"
-  },
-  {
-    "name": "pPoloniexEther",
-    "title": "Poloniex Bitcoin/Ether (\u0243/Ether) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexEtherColor",
-    "title": "Poloniex Bitcoin/Ether Ticker color",
-    "type": "color",
-    "value": "#FFF"
-  },
-  {
-    "name": "pPoloniexEtherClassic",
-    "title": "Poloniex Bitcoin/Ethereum Classic (\u0243/ETC) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pPoloniexEtherClassicColor",
-    "title": "Poloniex Bitcoin/Ethereum Classic Ticker color",
     "type": "color",
     "value": "#FFF"
   },
@@ -746,5 +624,158 @@
     "title": "Kraken USD/Ether Ticker color",
     "type": "color",
     "value": "#FFF"
-  }]
+  },
+  {
+    "name": "pPoloniexBelaCoin",
+    "title": "Poloniex Bitcoin/Belacoin (\u0243/BELA) ticker?",
+    "description": "Currencies from Poloniex Exchange",
+    "type": "bool",
+    "value": false
+  },
+  {
+    "name": "pPoloniexBitshares",
+    "title": "Poloniex Bitcoin/ (\u0243/BTS) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexBitsharesColor",
+    "title": "Poloniex Bitcoin/Bitshares Ticker color",
+    "type": "color",
+    "value": "#131F37"
+  },
+  {
+    "name": "pPoloniexBitcoindark",
+    "title": "Poloniex Bitcoin/Bitcoindark (\u0243/BTCD) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexBitcoindarkColor",
+    "title": "Poloniex Bitcoin/BitcoinDark Ticker color",
+    "type": "color",
+    "value": "#000000"
+  },
+  {
+    "name": "pPoloniexBurst",
+    "title": "Poloniex Bitcoin/Burst (\u0243/BURST) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexBurstColor",
+    "title": "Poloniex Bitcoin/Burst Ticker color",
+    "type": "color",
+    "value": "#FFF"
+  },
+  {
+    "name": "pPoloniexDash",
+    "title": "Poloniex Bitcoin/Dash (\u0243/DASH) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexDashColor",
+    "title": "Poloniex Bitcoin/Dash Ticker color",
+    "type": "color",
+    "value": "#1c75bc"
+  },
+  {
+    "name": "pPoloniexEther",
+    "title": "Poloniex Bitcoin/Ether (\u0243/ETH) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexEtherColor",
+    "title": "Poloniex Bitcoin/Ether Ticker color",
+    "type": "color",
+    "value": "#FFF"
+  },
+  {
+    "name": "pPoloniexEtherClassic",
+    "title": "Poloniex Bitcoin/ETC (\u0243/ETC) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexEtherClassicColor",
+    "title": "Poloniex Bitcoin/Ethereum Classic Ticker color",
+    "type": "color",
+    "value": "#FFF"
+  },
+  {
+    "name": "pPoloniexLiteCoin",
+    "title": "Poloniex Bitcoin/Litecoin (\u0243/LTC) ticker?",
+    "type": "bool",
+    "value": false
+  },
+  {
+    "name": "pPoloniexMaidsafe",
+    "title": "Poloniex Bitcoin/Maidsafe (\u0243/MAID) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexMaidsafeColor",
+    "title": "Poloniex Bitcoin/Maidsafe Ticker color",
+    "type": "color",
+    "value": "#000000"
+  },
+  {
+    "name": "pPoloniexMonero",
+    "title": "Poloniex Bitcoin/Monero (\u0243/XMR) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexMoneroColor",
+    "title": "Poloniex Bitcoin/Monero Ticker color",
+    "type": "color",
+    "value": "#413ADF"
+  },
+  {
+    "name": "pPoloniexNxt",
+    "title": "Poloniex Bitcoin/NXT (\u0243/NXT) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexNxtColor",
+    "title": "Poloniex Bitcoin/Nxt Ticker color",
+    "type": "color",
+    "value": "#413ADF"
+  },
+  {
+    "name": "pPoloniexPascal",
+    "title": "Poloniex Bitcoin/Pascal (\u0243/PASC) ticker?",
+    "type": "bool",
+    "value": false
+  },
+  {
+    "name": "pPoloniexNem",
+    "title": "Poloniex Bitcoin/NEM coin (\u0243/XEM) ticker?",
+    "type": "bool",
+    "value": false
+  },
+  {
+    "name": "pPoloniexRipple",
+    "title": "Poloniex Bitcoin/Ripple (\u0243/XRP) ticker?",
+    "type": "bool",
+    "value": false
+  },
+  {
+    "name": "pPoloniexMoneroUSD",
+    "title": "Poloniex USD/Monero ($/XMR) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexMoneroUSDColor",
+    "title": "Poloniex USD/Monero Ticker color",
+    "type": "color",
+    "value": "#413ADF"
+  },
+  {
+    "name": "pPoloniexDashUSD",
+    "title": "Poloniex USD/Dashcoin ($/DASH) ticker?",
+    "type": "bool",
+    "value": false
+  },{
+    "name": "pPoloniexDashUSDColor",
+    "title": "Poloniex $/Dash Ticker color",
+    "type": "color",
+    "value": "#1c75bc"
+  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,19 @@
       }]
   },
   {
+  	"name": "show-currency-name",
+  	"title": "Display currency initials in front of ticker?"
+  	"type": "bool",
+  	"value": false
+  },
+  {
+  	"name": "do-not-round",
+  	"title": "Do not make rounding for currency value"
+  	"type": "bool",
+  	"value": false
+  },
+  
+  {
     "name": "show-updates",
     "title": "Show new features page when there is an update",
     "type": "bool",


### PR DESCRIPTION
Created two new options to preferences:
- "Display currency initials in front of ticker?" boolean value. This shows currency "code" in front of value, e.g. Ethereum currency code is ETH
- "Do not make rounding for currency value?" boolean value. This prevents rounding of price in order to show exact value from currency. This is mostly useful when prices are shown in BTC rather than USD.